### PR TITLE
fix(desktop): externalize playwright from sidecar bundle

### DIFF
--- a/ui/binaries/build-sidecar.sh
+++ b/ui/binaries/build-sidecar.sh
@@ -13,7 +13,11 @@ fi
 echo "Building polpo-server sidecar..."
 
 cd "$REPO_ROOT"
-bun build dist/cli/index.js --compile --outfile "$SCRIPT_DIR/polpo-server${EXT}"
+bun build dist/cli/index.js --compile \
+  --external chromium-bidi \
+  --external playwright-core \
+  --external playwright \
+  --outfile "$SCRIPT_DIR/polpo-server${EXT}"
 
 echo "Sidecar built: $SCRIPT_DIR/polpo-server${EXT}"
 ls -lh "$SCRIPT_DIR/polpo-server${EXT}"


### PR DESCRIPTION
## Summary
- Externalize `chromium-bidi`, `playwright-core`, and `playwright` from the bun sidecar build to fix desktop packaging failure on macOS