### PR TITLE
v0.1.23: Fix website downloads + agent memory tools + stop button fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "The open-source platform for AI agent teams",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -668,6 +668,7 @@ export class Orchestrator extends TypedEmitter {
   getStore(): TaskStore { return this.registry; }
   getRunStore(): RunStore { return this.runStore; }
   getPolpoDir(): string { return this.polpoDir; }
+  getMemoryStore(): MemoryStore { return this.memoryStore; }
   getVaultStore(): EncryptedVaultStore | undefined { return this.vaultStore; }
 
   /**

--- a/src/server/routes/completions.ts
+++ b/src/server/routes/completions.ts
@@ -34,6 +34,8 @@ import { dirname } from "node:path";
 import { buildSystemPrompt } from "../../adapters/engine.js";
 import { createCodingTools, createAllTools } from "../../tools/coding-tools.js";
 import { createInkTools } from "../../tools/ink-tools.js";
+import { createMemoryTools } from "../../tools/memory-tools.js";
+import { agentMemoryScope } from "@polpo-ai/core";
 import { resolveAgentVault } from "../../vault/index.js";
 
 const MAX_TURNS = 20;
@@ -391,6 +393,18 @@ export function completionRoutes(orchestrator: Orchestrator, apiKeys?: string[])
           outputDir: undefined,
           polpoDir,
         });
+      }
+
+      // Memory tools — scoped to this agent only
+      const memoryStore = orchestrator.getMemoryStore();
+      if (memoryStore) {
+        agentToolInstances.push(...createMemoryTools(memoryStore, agentConfig.name));
+      }
+
+      // Inject existing agent memory into the system prompt
+      const agentMemory = await memoryStore?.get(agentMemoryScope(agentConfig.name));
+      if (agentMemory) {
+        fullSystemPrompt += `\n\n## Your persistent memory\n\n${agentMemory}`;
       }
 
       effectiveTools = agentToolInstances as Tool[];

--- a/src/tools/memory-tools.ts
+++ b/src/tools/memory-tools.ts
@@ -1,0 +1,129 @@
+/**
+ * Memory tools for agents — scoped to a single agent's private memory.
+ *
+ * These tools let an agent read and write its own persistent memory
+ * during direct-chat sessions. The agent scope is baked in at creation
+ * time so the agent cannot access other agents' or shared memory.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { MemoryStore } from "@polpo-ai/core";
+import { agentMemoryScope } from "@polpo-ai/core";
+
+// ── Tool names ──
+
+export const ALL_MEMORY_TOOL_NAMES = [
+  "memory_get",
+  "memory_save",
+  "memory_append",
+  "memory_update",
+] as const;
+
+export type MemoryToolName = (typeof ALL_MEMORY_TOOL_NAMES)[number];
+
+// ── Schemas ──
+
+const MemoryGetSchema = Type.Object({});
+
+const MemorySaveSchema = Type.Object({
+  content: Type.String({ description: "The full memory content to save (overwrites existing)" }),
+});
+
+const MemoryAppendSchema = Type.Object({
+  text: Type.String({ description: "Text to append to your memory" }),
+});
+
+const MemoryUpdateSchema = Type.Object({
+  old_text: Type.String({ description: "Exact substring in your memory to find" }),
+  new_text: Type.String({ description: "Replacement text" }),
+});
+
+// ── Factory ──
+
+/**
+ * Create memory tools for an agent, scoped to that agent's private memory.
+ *
+ * @param store   The MemoryStore instance
+ * @param agent   The agent name — tools will only access `agent:<name>` scope
+ */
+export function createMemoryTools(
+  store: MemoryStore,
+  agent: string,
+): AgentTool<any>[] {
+  const scope = agentMemoryScope(agent);
+
+  const memoryGet: AgentTool<typeof MemoryGetSchema> = {
+    name: "memory_get",
+    label: "Read Memory",
+    description:
+      "Read your persistent memory. This memory survives across sessions " +
+      "and contains your personal notes, learnings, and context. " +
+      "Returns empty string if you have no saved memory yet.",
+    parameters: MemoryGetSchema,
+    async execute() {
+      const content = await store.get(scope);
+      return {
+        content: [{ type: "text" as const, text: content || "(no memory saved yet)" }],
+        details: { scope },
+      };
+    },
+  };
+
+  const memorySave: AgentTool<typeof MemorySaveSchema> = {
+    name: "memory_save",
+    label: "Save Memory",
+    description:
+      "Overwrite your entire persistent memory with new content. " +
+      "Use this when you want to restructure or rewrite your memory completely. " +
+      "For adding a single note, prefer memory_append instead.",
+    parameters: MemorySaveSchema,
+    async execute(_toolCallId, params) {
+      await store.save(params.content, scope);
+      return {
+        content: [{ type: "text" as const, text: `Memory saved (${params.content.length} chars).` }],
+        details: { scope, chars: params.content.length },
+      };
+    },
+  };
+
+  const memoryAppend: AgentTool<typeof MemoryAppendSchema> = {
+    name: "memory_append",
+    label: "Append to Memory",
+    description:
+      "Append a timestamped line to your persistent memory. " +
+      "Good for quick notes, learnings, or observations you want to remember.",
+    parameters: MemoryAppendSchema,
+    async execute(_toolCallId, params) {
+      await store.append(params.text, scope);
+      return {
+        content: [{ type: "text" as const, text: `Appended to memory: "${params.text}"` }],
+        details: { scope },
+      };
+    },
+  };
+
+  const memoryUpdate: AgentTool<typeof MemoryUpdateSchema> = {
+    name: "memory_update",
+    label: "Update Memory",
+    description:
+      "Find and replace a specific section in your memory. " +
+      "The old_text must be an exact unique substring of your current memory.",
+    parameters: MemoryUpdateSchema,
+    async execute(_toolCallId, params) {
+      const result = await store.update(params.old_text, params.new_text, scope);
+      if (result === true) {
+        return {
+          content: [{ type: "text" as const, text: "Memory updated successfully." }],
+          details: { scope, success: true },
+        };
+      }
+      return {
+        content: [{ type: "text" as const, text: `Failed to update memory: ${result}` }],
+        details: { scope, success: false },
+      };
+    },
+  };
+
+  return [memoryGet, memorySave, memoryAppend, memoryUpdate];
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.23",
   "license": "MIT",
   "author": {
     "name": "Lumea Labs",

--- a/ui/src/pages/chat.tsx
+++ b/ui/src/pages/chat.tsx
@@ -2321,7 +2321,7 @@ function ChatInput() {
                 <MicButton onTranscript={setTextareaValue} disabled={inputDisabled} />
                 <PromptInputSubmit
                   status={isLoading ? "streaming" : undefined}
-                  disabled={inputDisabled}
+                  disabled={isLoading ? false : inputDisabled}
                   onStop={stop}
                 />
               </div>

--- a/website/src/components/DownloadButton.tsx
+++ b/website/src/components/DownloadButton.tsx
@@ -69,8 +69,8 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
     label: "macOS",
     icon: Apple,
     assets: [
-      { label: "DMG", filename: "Polpo-{version}.dmg" },
-      { label: "ZIP", filename: "Polpo-{version}-mac.zip" },
+      { label: "DMG", filename: "Polpo-{version}-arm64.dmg" },
+      { label: "ZIP", filename: "Polpo-{version}-arm64-mac.zip" },
     ],
   },
   windows: {
@@ -78,7 +78,7 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
     label: "Windows",
     icon: Monitor, // placeholder, we use WindowsIcon
     assets: [
-      { label: "Installer", filename: "Polpo-Setup-{version}.exe" },
+      { label: "Installer", filename: "Polpo.Setup.{version}.exe" },
     ],
   },
   unknown: {


### PR DESCRIPTION
## Summary

- **fix(website):** Correct download button filenames to match actual release assets — Windows `.exe` uses dots not dashes, Mac assets include `-arm64` suffix
- **feat(memory):** Add agent-scoped memory tools (`memory_get`, `memory_save`, `memory_append`, `memory_update`) for agent-direct chat mode
- **fix(ui):** Enable stop button during streaming (was incorrectly disabled by `isLoading` condition)
- **chore:** Bump version to 0.1.23 (root + UI)

## Changes

### Website download button (`website/src/components/DownloadButton.tsx`)
- `Polpo-Setup-{v}.exe` → `Polpo.Setup.{v}.exe`
- `Polpo-{v}.dmg` → `Polpo-{v}-arm64.dmg`
- `Polpo-{v}-mac.zip` → `Polpo-{v}-arm64-mac.zip`

### Agent memory tools (`src/tools/memory-tools.ts`)
- New file with 4 memory tools scoped to agent's private memory namespace
- Injected into agent-direct completions endpoint
- Agent memory summary included in system prompt

### Stop button fix (`ui/src/pages/chat.tsx`)
- `disabled={isLoading ? false : inputDisabled}` — stop button now works during streaming

## After merge
Tag `v0.1.23` and push to trigger release workflow.