### PR TITLE
fix: CLI projects resolves orgId, session token auth, bump 0.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "The open-source platform for AI agent teams",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/cloud/projects.ts
+++ b/src/cli/commands/cloud/projects.ts
@@ -1,52 +1,73 @@
 /**
- * polpo-cloud projects — manage projects (session auth, limited CLI support).
- *
- * NOTE: Projects API uses session auth (Better Auth), not API key auth.
- * These commands are stubs that use API key auth — they may not work
- * with the current control plane auth model.
+ * polpo cloud projects — manage projects via session token auth.
  */
 import type { Command } from "commander";
 import { loadCredentials } from "./config.js";
-import { createApiClient } from "./api.js";
+import { createApiClient, type ApiClient } from "./api.js";
+
+/**
+ * Fetch the user's first org ID. The server requires an orgId for
+ * project list/create, so we resolve it automatically.
+ */
+async function resolveOrgId(client: ApiClient): Promise<string> {
+  const res = await client.get<any[]>("/v1/orgs");
+  if (res.status !== 200) {
+    console.error(
+      `Failed to fetch organizations (status ${res.status}). Are you logged in?`,
+    );
+    process.exit(1);
+  }
+
+  const orgs = Array.isArray(res.data) ? res.data : [];
+  if (orgs.length === 0) {
+    console.error(
+      "No organizations found. Create one in the dashboard first.",
+    );
+    process.exit(1);
+  }
+
+  return orgs[0].id;
+}
 
 export function registerProjectsCommand(program: Command): void {
   const projects = program
     .command("projects")
-    .description("Manage projects (limited — uses API key auth)");
+    .description("Manage cloud projects");
 
   projects
     .command("list")
     .description("List projects")
-    .action(async () => {
+    .option("--org <org-id>", "Organization ID (auto-detected if omitted)")
+    .action(async (opts) => {
       const creds = loadCredentials();
       if (!creds) {
-        console.error(
-          "Not logged in. Run: polpo-cloud login --api-key <key>",
-        );
+        console.error("Not logged in. Run: polpo login --api-key <key>");
         process.exit(1);
       }
 
       const client = createApiClient(creds);
 
       try {
-        const res = await client.get<any>("/v1/projects");
+        const orgId = opts.org ?? (await resolveOrgId(client));
+        const res = await client.get<any[]>(
+          `/v1/projects?orgId=${encodeURIComponent(orgId)}`,
+        );
+
         if (res.status === 200) {
-          const projects = res.data?.data ?? [];
-          if (projects.length === 0) {
+          const list = Array.isArray(res.data) ? res.data : [];
+          if (list.length === 0) {
             console.log("No projects found.");
           } else {
-            for (const p of projects) {
+            for (const p of list) {
               const status = p.status ? ` [${p.status}]` : "";
               console.log(`  ${p.name ?? p.id}${status}`);
             }
           }
-        } else if (res.status === 401) {
-          console.error(
-            "Error: Projects API requires session auth. Use the web dashboard to manage projects.",
-          );
-          process.exit(1);
         } else {
-          console.error("Error: status " + res.status);
+          const data = res.data as any;
+          console.error(
+            "Error: " + (data?.error ?? `status ${res.status}`),
+          );
           process.exit(1);
         }
       } catch (err: any) {
@@ -58,35 +79,40 @@ export function registerProjectsCommand(program: Command): void {
   projects
     .command("create <name>")
     .description("Create a project")
-    .option("--org <org-id>", "Organization ID")
+    .option("--org <org-id>", "Organization ID (auto-detected if omitted)")
     .action(async (name: string, opts) => {
       const creds = loadCredentials();
       if (!creds) {
-        console.error(
-          "Not logged in. Run: polpo-cloud login --api-key <key>",
-        );
+        console.error("Not logged in. Run: polpo login --api-key <key>");
         process.exit(1);
       }
 
       const client = createApiClient(creds);
 
       try {
+        const orgId = opts.org ?? (await resolveOrgId(client));
+
+        // Derive slug from name: lowercase, replace non-alphanumeric with dashes
+        const slug = name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-|-$/g, "");
+
         const res = await client.post<any>("/v1/projects", {
+          orgId,
           name,
-          orgId: opts.org,
+          slug,
         });
 
         if (res.status >= 200 && res.status < 300) {
-          const project = res.data?.data ?? res.data;
+          const project = res.data;
           console.log(`Project "${name}" created.`);
           if (project?.id) {
             console.log(`  ID: ${project.id}`);
           }
-        } else if (res.status === 401) {
-          console.error(
-            "Error: Projects API requires session auth. Use the web dashboard to manage projects.",
-          );
-          process.exit(1);
+          if (project?.slug) {
+            console.log(`  Slug: ${project.slug}`);
+          }
         } else {
           const data = res.data as any;
           console.error(


### PR DESCRIPTION
## Summary

- `polpo projects list` now fetches orgs first to resolve orgId automatically
- `polpo projects create` passes orgId + auto-derives slug
- CLI login saves session token (not API key) for Better Auth Bearer plugin
- Removed stale "session auth" error messages
- Published polpo-ai@0.3.11

## Test plan

- [ ] `polpo login` completes browser flow
- [ ] `polpo projects list` returns projects
- [ ] `polpo projects create myproject` creates a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)